### PR TITLE
Fix issue with Cordova package failing to install

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,8 +1,8 @@
 Package.describe({
-  name: 'tripflex:fix-back-button-android',
+  name: 'remcoder:fix-back-button-android',
   version: '0.0.2',
-  summary: 'Fixes the native back button on Android (fork of remcoder updated to work with org.android.tools.suspend)',
-  git: 'https://github.com/tripflex/fix-back-button-android',
+  summary: 'Fixes the native back button on Android',
+  git: 'https://github.com/remcoder/fix-back-button-android',
   documentation: 'README.md'
 });
 

--- a/package.js
+++ b/package.js
@@ -1,8 +1,8 @@
 Package.describe({
-  name: 'remcoder:fix-back-button-android',
-  version: '0.0.1',
-  summary: 'Fixes the native back button on Android',
-  git: 'https://github.com/remcoder/fix-back-button-android',
+  name: 'tripflex:fix-back-button-android',
+  version: '0.0.2',
+  summary: 'Fixes the native back button on Android (fork of remcoder updated to work with org.android.tools.suspend)',
+  git: 'https://github.com/tripflex/fix-back-button-android',
   documentation: 'README.md'
 });
 
@@ -12,6 +12,6 @@ Package.onUse(function(api) {
 });
 
 Cordova.depends({
-  'org.android.tools.suspend':'0.1.2'
+  'org.android.tools.suspend':'https://github.com/Lamerchun/org.android.tools.suspend.git#0dbb52cca0244ba22a8c7975895f0f45d2e9a4a9'
 });
 


### PR DESCRIPTION
The `org.android.tools.suspend` package no longer exists on npm, and as such, when meteor attempts to build the dependency, it fails.  

Updated the `package.js` to use the github repo for the dep